### PR TITLE
refactor: replace mutex-protected maps with sync.Map for better concurrency

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -13,10 +13,7 @@ func (c *Controller[T]) Get() (T, error) {
 
 // Peek retrieves the cached value without resolving
 func (c *Controller[T]) Peek() (T, bool) {
-	c.scope.mu.RLock()
-	defer c.scope.mu.RUnlock()
-
-	val, ok := c.scope.cache[c.executor]
+	val, ok := c.scope.cache.Load(c.executor)
 	if !ok {
 		var zero T
 		return zero, false
@@ -36,9 +33,7 @@ func (c *Controller[T]) Set(newVal T) error {
 
 // Release invalidates the cached value
 func (c *Controller[T]) Release() error {
-	c.scope.mu.Lock()
-	defer c.scope.mu.Unlock()
-	delete(c.scope.cache, c.executor)
+	c.scope.cache.Delete(c.executor)
 	return nil
 }
 
@@ -53,8 +48,6 @@ func (c *Controller[T]) Reload() (T, error) {
 
 // IsCached checks if the value is currently cached
 func (c *Controller[T]) IsCached() bool {
-	c.scope.mu.RLock()
-	defer c.scope.mu.RUnlock()
-	_, ok := c.scope.cache[c.executor]
+	_, ok := c.scope.cache.Load(c.executor)
 	return ok
 }


### PR DESCRIPTION
## Summary
- Replace cache map with sync.Map in Scope for thread-safe operations
- Replace tags map with sync.Map in Scope  
- Update controller methods to use sync.Map operations (Load, Store, Delete)
- Remove explicit mutex locking in favor of sync.Map's built-in concurrency
- Improves performance by reducing lock contention in concurrent scenarios

## Changes
- **scope.go**: Refactored cache and tags from mutex-protected maps to sync.Map
- **controller.go**: Updated controller methods to use sync.Map operations
- **CLAUDE.md**: Added project documentation file

## Test plan
- [ ] Run existing test suite to ensure no regressions
- [ ] Test concurrent access patterns
- [ ] Verify performance improvements under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)